### PR TITLE
listen to local ip for running in docker

### DIFF
--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -4,7 +4,7 @@ const common = require("./webpack.common.js");
 module.exports = merge(common, {
   mode: "development",
   devServer: {
-    host: "localhost",
+    host: "0.0.0.0",
     historyApiFallback: true, // make sure Router works by redirecting 404 back to entry point
     port: 3000,
     open: true


### PR DESCRIPTION
Allow listening from local IP (0.0.0.0) for running inside docker. Tested in Docker Desktop (Windows).
@suhadaudd11 
